### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.2.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ results from workflows in a format that is easily editable and formatable.
 
 Copy and edit the excel.yaml.example into the /opt/stackstorm/configs directory.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Important Notes about the Excel File
 
 If the excel file does not exist, a new spreadsheet will be created with

--- a/actions/get_keys_for_columns.yaml
+++ b/actions/get_keys_for_columns.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_keys_for_columns"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "returns an array of the row keys for a given sheet in the excel file"
 enabled: true
 entry_point: "get_keys_for_columns.py"

--- a/actions/get_keys_for_rows.yaml
+++ b/actions/get_keys_for_rows.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_keys_for_rows"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "returns an array of the row keys for a given sheet in the excel file"
 enabled: true
 entry_point: "get_keys_for_rows.py"

--- a/actions/get_sheets.yaml
+++ b/actions/get_sheets.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_sheets"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "returns an array in json format of the sheet names in the excel file"
 enabled: true
 entry_point: "get_sheets.py"

--- a/actions/get_variables.yaml
+++ b/actions/get_variables.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_variables"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "returns a json object of the variables for a given key in the excel file"
 enabled: true
 entry_point: "get_variables.py"

--- a/actions/set_variables.yaml
+++ b/actions/set_variables.yaml
@@ -1,6 +1,6 @@
 ---
 name: "set_variables"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "adds/updates variables to a spreadsheet"
 enabled: true
 entry_point: "set_variables.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : excel
 description : excel actions to read and write variables to an excel file 
-version : 0.1.0
+version : 0.2.0
 author : Tim Braly
 email : tbraly@brocade.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.