### PR TITLE
Update config.schema.yaml

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -4,7 +4,7 @@
     type: "string"
     secret: false
     required: false
-    default: "NONE"
+    default: ""
   key_column:
     description: "Column in the spreadsheet that contains the key field"
     type: "integer"

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -4,6 +4,7 @@
     type: "string"
     secret: false
     required: false
+    default: "NONE"
   key_column:
     description: "Column in the spreadsheet that contains the key field"
     type: "integer"


### PR DESCRIPTION
Stackstorm version 2.5 scheme seems to require a default value for each key. The excel_file var did not have a default set.

Here is the error that I saw after fresh install of the excel pack on Stackstorm version 2.5
````
root@EWC-v2:/opt/stackstorm/packs# st2 run excel.get_sheets excel_file='/home/stanley/firmwareVersions.xlsx'
.
id: 5a04acc0b2ee32071a790791
status: failed
parameters:
  excel_file: /home/stanley/firmwareVersions.xlsx
result:
  exit_code: 1
  result: None
  stderr: "Traceback (most recent call last):\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 259, in <module>\n    obj.run()\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 154, in run\n    action = self._get_action_instance()\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 229, in _get_action_instance\n    action_service=action_service)\n  File \"/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/runners/utils.py\", line 85, in get_action_class_instance\n    action_instance = action_cls(**kwargs)\n  File \"/opt/stackstorm/packs/excel/actions/lib/excel_action.py\", line 20, in __init__\n    self._excel_file = self.config['excel_file']\nKeyError: 'excel_file'\n"
 ````