### PR TITLE
Add support for integer and float keys & values for set and get variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,17 @@
 # Change Log
 
+## 0.2.3
+
+- Add support for integer or float keys and values
+
 ## 0.2.2
 
 - Updated `config.schema.yaml` file. `excel_file` now has default ""
-  
+
 ## 0.2.1
 
 - Updated Action import path
-  
+
 ## 0.2.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/actions/get_variables.py
+++ b/actions/get_variables.py
@@ -11,12 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from lib import excel_action, excel_reader
+from lib import excel_action, excel_reader, string_converter
 import json
 
 
 class GetExcelVariablesAction(excel_action.ExcelAction):
-    def run(self, key, sheet='Sheet', variables='[]', excel_file=None,
+    def run(self, key, sheet='Sheet1', variables='[]', excel_file=None,
             key_column=None, variable_name_row=None):
 
         self.replace_defaults(excel_file, key_column, variable_name_row)
@@ -26,7 +26,10 @@ class GetExcelVariablesAction(excel_action.ExcelAction):
                         var_name_row=self._var_name_row,
                         strict=True)
 
+        key = string_converter.convert_string_to_float_int(key)
+
         vfk = excel.get_variables_for_key(key)
+
         if variables == '[]':  # default
             return vfk
 

--- a/actions/lib/excel_reader.py
+++ b/actions/lib/excel_reader.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 
 from openpyxl import Workbook, load_workbook
+import string_converter
 import os
 import time
 
@@ -162,9 +163,14 @@ class ExcelReader(object):
 
     def get_row_for_key(self, key):
         ''' Returns the row for a given key, or -1 if not matched '''
-        if len(key) > 255:
-            self._unlock_file()
-            raise ValueError("Key exceeds 255 characters")
+        try:
+            if len(key) > 255:
+                self._unlock_file()
+                raise ValueError("Key exceeds 255 characters")
+        except TypeError:
+            if isinstance(key, int) or isinstance(key, float):
+                pass
+
         if key in self._keys:
             return self._keys[key]
         return -1
@@ -219,17 +225,29 @@ class ExcelReader(object):
 
         # Fill in values
         for k, value in dictionary.items():
-            # is key or value greater the excel 256 character limit?
-            if len(k) > 255:
+
+            k = string_converter.convert_string_to_float_int(k)
+
+            # is k greater the excel 256 character limit?
+            if isinstance(k, int) or isinstance(k, float):
+                pass
+            elif len(k) > 255:
                 self._unlock_file()
                 raise ValueError("Variable name exceeds 255 characters")
-            if len(k) == 0:
+            elif len(k) == 0:
                 self._unlock_file()
                 raise ValueError("Variable name is blank")
-            if len(value) > 32767:
+
+            value = string_converter.convert_string_to_float_int(value)
+
+            # is value greater the excel 256 character limit?
+            if isinstance(value, int) or isinstance(value, float):
+                pass
+            elif len(value) > 32767:
                 self._unlock_file()
                 raise ValueError("Variable value exceeds 32,767 characters")
-            if not k == key:
+
+            if k != key:
                 if k in variables:
                     self._ws.cell(column=variables[k], row=row).value = value
                 else:
@@ -246,6 +264,7 @@ class ExcelReader(object):
                         self._unlock_file()
                         raise ValueError("Column '%s' missing in sheet '%s'" %
                                          (k, self._sheet_name))
+
 
 if __name__ == "__main__":
     pass

--- a/actions/lib/string_converter.py
+++ b/actions/lib/string_converter.py
@@ -1,0 +1,20 @@
+from ast import literal_eval
+
+
+def convert_string_to_float_int(string):
+
+    if isinstance(string, str) or isinstance(string, unicode):
+        try:
+            # evaluate the string to float, int or bool
+            value = literal_eval(string)
+        except Exception:
+            value = string
+    else:
+        value = string
+
+    # check if the the value is float or int
+    if isinstance(value, float):
+        if value.is_integer():
+            return int(value)
+        return value
+    return value

--- a/actions/set_variables.py
+++ b/actions/set_variables.py
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from lib import excel_action, excel_reader
+from lib import excel_action, excel_reader, string_converter
 import json
 
 
@@ -26,6 +26,9 @@ class GetExcelVariablesAction(excel_action.ExcelAction):
         excel.set_sheet(sheet, key_column=self._key_column,
                         var_name_row=self._var_name_row,
                         strict=strict)
+
+        key = string_converter.convert_string_to_float_int(key)
+
         excel.set_values_for_variables(key, data)
         excel.save()
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : excel
-description : excel actions to read and write variables to an excel file 
-version: 0.2.2
+description : excel actions to read and write variables to an excel file
+version: 0.2.3
 author : Tim Braly
 email : tbraly@brocade.com


### PR DESCRIPTION
Get variable based on the `int` key:
```bash
$ st2 run excel.get_variables key=23 excel_file='/home/vagrant/testme.xlsx'
.
id: 5a1e19746d90e814960b4630
status: succeeded
parameters:
  excel_file: /home/vagrant/testme.xlsx
  key: '23'
result:
  exit_code: 0
  result:
    this works: 'no'
    title: 99.99
  stderr: ''
  stdout: ''
```
Set `int` variable based on the `int` key:
```bash
$ st2 run excel.set_variables key=23 sheet=Sheet1 excel_file='/home/vagrant/testme.xlsx' variables={'"title":1200'}
.
id: 5a1e199d6d90e814960b4633
status: succeeded
parameters:
  excel_file: /home/vagrant/testme.xlsx
  key: '23'
  sheet: Sheet1
  variables: '{"title":1200}'
result:
  exit_code: 0
  result: Success
  stderr: ''
  stdout: ''
```
Get updated variable `title` in this case based on the `int` key:
```bash
$ st2 run excel.get_variables key=23 excel_file='/home/vagrant/testme.xlsx'
.
id: 5a1e19a36d90e814960b4636
status: succeeded
parameters:
  excel_file: /home/vagrant/testme.xlsx
  key: '23'
result:
  exit_code: 0
  result:
    this works: 'no'
    title: 1200
  stderr: ''
  stdout: ''
vagrant@u14:~$
```