### PR TITLE
Add strict option to get_keys_for_rows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.1
+
+- Add unstrict support to get_keys_for_rows
+
 ## 0.3.0
 
 - Add support for deleting rows

--- a/actions/get_keys_for_rows.py
+++ b/actions/get_keys_for_rows.py
@@ -16,13 +16,17 @@ from lib import excel_action, excel_reader
 
 class GetExcelSheetsAction(excel_action.ExcelAction):
     def run(self, sheet, excel_file=None, key_column=None,
-            variable_name_row=None):
+            variable_name_row=None, strict=True):
 
         self.replace_defaults(excel_file, key_column, variable_name_row)
 
         excel = excel_reader.ExcelReader(self._excel_file)
-        excel.set_sheet(sheet, key_column=self._key_column,
+        try:
+            excel.set_sheet(sheet, key_column=self._key_column,
                         var_name_row=self._var_name_row,
-                        strict=True)
-
+                        strict=strict)
+        except excel_reader.UnlockedSheetError:
+            # Sheet doesn't exist and we haven't locked sheet as do not
+            # want to modify it on get
+           return []
         return excel.get_keys()

--- a/actions/get_keys_for_rows.py
+++ b/actions/get_keys_for_rows.py
@@ -28,5 +28,5 @@ class GetExcelSheetsAction(excel_action.ExcelAction):
         except excel_reader.UnlockedSheetError:
             # Sheet doesn't exist and we haven't locked sheet as do not
             # want to modify it on get
-           return []
+            return []
         return excel.get_keys()

--- a/actions/get_keys_for_rows.yaml
+++ b/actions/get_keys_for_rows.yaml
@@ -23,3 +23,8 @@ parameters:
     type: "string"
     description: "Excel sheet name"
     required: true
+  strict:
+    type: "boolean"
+    description: "When enabled, Sheet must exist & Variable Names must exist"
+    required: false
+    default: True

--- a/actions/lib/excel_reader.py
+++ b/actions/lib/excel_reader.py
@@ -147,7 +147,7 @@ class ExcelReader(object):
                 if self._lock:
                     self._ws = self._wb.create_sheet(self._sheet_name)
                 else:
-                    raise IOError("File not locked for modification")
+                    raise UnlockedSheetError("File not locked for modification")
             else:
                 self._unlock_file()
                 raise KeyError("Sheet '%s' not found" % self._sheet_name)
@@ -288,6 +288,9 @@ class ExcelReader(object):
         del self._keys[key]
         self._data_end_row -= 1
 
+
+class UnlockedSheetError(IOError):
+    pass
 
 if __name__ == "__main__":
     pass

--- a/actions/lib/excel_reader.py
+++ b/actions/lib/excel_reader.py
@@ -292,5 +292,6 @@ class ExcelReader(object):
 class UnlockedSheetError(IOError):
     pass
 
+
 if __name__ == "__main__":
     pass

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,7 +1,7 @@
 ---
 name : excel
 description : Read and Write Excel spreadsheets
-version: 0.3.0
+version: 0.3.1
 author : Tim Braly
 email : tbraly@brocade.com
 python_versions:

--- a/tests/test_action_get_keys_for_rows.py
+++ b/tests/test_action_get_keys_for_rows.py
@@ -99,3 +99,27 @@ class GetKeysForRowsTestCase(ExcelBaseActionTestCase):
         action = self.get_action_instance(self.full_config)
         with self.assertRaises(ValueError):
             action.run('sheet3', "mock_excel.xlsx")
+
+    @mock.patch('openpyxl.load_workbook', return_workbook)
+    @mock.patch('os.path.isfile', ExcelBaseActionTestCase.mock_file_exists)
+    def test_get_keys_sheet_not_exist_strict(self):
+        action = self.get_action_instance(self.full_config)
+        with self.assertRaises(KeyError):
+            action.run('sheet3', "mock_excel.xlsx", strict=True)
+
+    @mock.patch('openpyxl.load_workbook', return_workbook)
+    @mock.patch('os.path.isfile', ExcelBaseActionTestCase.mock_file_exists)
+    def test_get_keys_sheet_not_exist_not_strict(self):
+        action = self.get_action_instance(self.full_config)
+        result = action.run('sheet3', "mock_excel.xlsx", strict=False)
+
+        self.assertIsNotNone(result)
+        self.assertEquals([], result)
+        GetKeysForRowsTestCase.WB.save.assert_not_called()
+
+    @mock.patch('openpyxl.load_workbook', return_workbook)
+    @mock.patch('os.path.isfile', mock.Mock(return_value=False))
+    def test_get_keys_spreadsheet_not_exist_not_strict(self):
+        action = self.get_action_instance(self.full_config)
+        with self.assertRaises(ValueError):
+            action.run('sheet3', "mock_excel.xlsx", strict=False)


### PR DESCRIPTION
Add strict option on get similar to strict on set.
If sheet does not exist then current behaviour is to exception on get.
Keep backwards compatible by default for strict being true
Add option to set strict to false, and then [] will be returned for keys if sheet does not exist.

Unlike set didn't want to create the sheet on get, so kept the lock as not set on gets. Side affect was that exception raised in the generic get_sheet in this case, which is handled in the action. Would have required a bigger re-write of generic function to avoid the throw and catch of exception, and harder to maintain backwards support - so therefore kept to the catch of exception in the action. But could go for a large re-write if preferred to avoid this.